### PR TITLE
Add `environment` variable to the production build

### DIFF
--- a/_config-production.yml
+++ b/_config-production.yml
@@ -1,1 +1,2 @@
 baseurl: /pwa-devdocs
+environment: public

--- a/src/_includes/layout/header-scripts.html
+++ b/src/_includes/layout/header-scripts.html
@@ -7,6 +7,10 @@
   };
 </script>
 
+
+
+{% if site.environment == "public" %}
+
 <!-- Hotjar Tracking Code for https://magento-research.github.io/pwa-devdocs/ -->
 <script>
     (function(h,o,t,j,a,r){
@@ -29,3 +33,6 @@
 
   gtag('config', '{{ site.google.analytics }}');
 </script>
+
+
+{% endif %}


### PR DESCRIPTION
And use it to disable analytics on non-production builds.

<!--
Thank you for your contribution!
 
Before submitting this Pull Request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-devdocs/.github/CONTRIBUTING.md
 
Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or summary to make the connection.
 
We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the mainteners' discretion.
-->
 
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
[ ] Imporvement

 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
When this Pull Request is merged, it will remove analytics scripts from non-production builds.
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional Information