### PR TITLE
Update Gemfile to use devdocs-stable theme branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'devdocs', :git => 'https://github.com/magento-devdocs/devdocs-theme.git', :branch => 'master'
+gem 'devdocs', :git => 'https://github.com/magento-devdocs/devdocs-theme.git', :branch => 'devdocs-stable'


### PR DESCRIPTION
<!--
Thank you for your contribution!
 
Before submitting this Pull Request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-devdocs/.github/CONTRIBUTING.md
 
Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or summary to make the connection.
 
We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the mainteners' discretion.
-->
 
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
[ ] Improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
When this Pull Request is merged, it will use `devdocs-stable` branch of the theme gem, instead of `master`. This is hopefully more secure.
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional Information