### PR TITLE
Remove redundant use of "PWA applications"

### DIFF
--- a/src/_config.yml
+++ b/src/_config.yml
@@ -1,5 +1,5 @@
 title: Magento PWA Documentation
-description: Everything you need to build a Magento PWA application.
+description: Everything you need to build a Magento PWA.
 
 source: src
 

--- a/src/_data/vars.yml
+++ b/src/_data/vars.yml
@@ -1,5 +1,5 @@
 # Site specific variables
 
 title: Magento PWA Documentation
-description: Everything you need to build a Magento PWA application.
+description: Everything you need to build a Magento PWA.
 repo: https://github.com/magento-research/pwa-devdocs

--- a/src/technologies/tools-libraries/index.md
+++ b/src/technologies/tools-libraries/index.md
@@ -50,7 +50,7 @@ whereas REST requires specialized endpoints for different data request combinati
 Unlike REST, which can require multiple server requests to aggregate data, 
 a single GraphQL request returns only the data needed and nothing more.
 
-Performance is an important metric for PWA applications.
+Performance is an important metric for PWAs.
 Using GraphQL improves this by reducing the number of server calls and the amount of data returned.
 
 


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
[ ] Bug fix
[ ] New topic
[x] Content rewrite
 
<!-- (REQUIRED) What does this PR change? -->
## Summary

PWA stands for progressive web app, and app stands for application, making "PWA
applications" redundant.
 

 
